### PR TITLE
Non-webkit browsers ignore the offset amount #2

### DIFF
--- a/jquery.singlePageNav.js
+++ b/jquery.singlePageNav.js
@@ -65,7 +65,12 @@ if (typeof Object.create !== 'function') {
                 self.scrollTo($elem, function() { 
                  
                     if (self.options.updateHash) {
-                        document.location.hash = link.hash;
+                         if (history.pushState) {
+                            history.pushState(null,null, link.hash)
+                        }
+                        else {
+                            location.hash = link.hash;
+                        }
                     }
 
                     self.setTimer();


### PR DESCRIPTION
Using the history object to update the hash if it's supported by the browser. Otherwise using the location object (for older browsers). Non-supportive browsers will still work as they do now, but modern browsers(non-webkit) will scroll to the correct position.
